### PR TITLE
serde: fix overflow on i64::MIN

### DIFF
--- a/src/core/dec.rs
+++ b/src/core/dec.rs
@@ -286,11 +286,12 @@ macro_rules! decode_ix {
                         },
                         major::NEGATIVE => {
                             let v = TypeNum::new(!(major::NEGATIVE << 5), byte).$decode_fn(reader)?;
-                            let v = v.checked_add(1)
-                                .ok_or(Error::Overflow { name: stringify!($t) })?;
                             let v = <$t>::try_from(v)
                                 .map_err(Error::CastOverflow)?;
-                            Ok(-v)
+                            let v = -v;
+                            let v = v.checked_sub(1)
+                                .ok_or(Error::Overflow { name: stringify!($t) })?;
+                            Ok(v)
                         },
                         _ => Err(Error::TypeMismatch {
                             name: stringify!($t),

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -474,3 +474,10 @@ fn test_serde_ignore_any_simple() {
     assert_eq!(bar.b, baz.b);
     assert_eq!(bar.c, baz.c);
 }
+
+#[test]
+fn test_regression_min_i64() {
+    let buf = to_vec(Vec::new(), &i64::MIN).unwrap();
+    let min_i64: i64 = from_slice(&buf).unwrap();
+    assert_eq!(min_i64, i64::MIN);
+}


### PR DESCRIPTION
When decoding the minimum value of i64 (-9223372036854775808), there
is an overflow error. With this fix it can be deserialized correctly.

The reason for the failure was the order of the operations. Prior to
this change the decoding had these steps:

 1. Decode the bytes into a `u64` => 9223372036854775807
 2. Add 1 => 9223372036854775808
 3. Cast to `i64` => error as `i64::MAX` is 9223372036854775807.
 4. Negate the number

The new steps are:

 1. Decode the bytes into a `u64` => 9223372036854775807
 2. Cast to `i64` => 9223372036854775807
 3. Negate the number => -9223372036854775807
 4. Subtract 1 => -9223372036854775808