### PR TITLE
core: expose a public in-memory writer

### DIFF
--- a/fuzz/fuzz_targets/decode.rs
+++ b/fuzz/fuzz_targets/decode.rs
@@ -4,42 +4,7 @@ use std::convert::Infallible;
 use libfuzzer_sys::fuzz_target;
 use cbor4ii::core::Value;
 use cbor4ii::core::dec::{ self, Decode };
-
-struct SliceReader<'a> {
-    buf: &'a [u8],
-    limit: usize
-}
-
-impl<'de> dec::Read<'de> for SliceReader<'de> {
-    type Error = Infallible;
-
-    #[inline]
-    fn fill<'b>(&'b mut self, want: usize) -> Result<dec::Reference<'de, 'b>, Self::Error> {
-        let len = core::cmp::min(self.buf.len(), want);
-        Ok(dec::Reference::Long(&self.buf[..len]))
-    }
-
-    #[inline]
-    fn advance(&mut self, n: usize) {
-        let len = core::cmp::min(self.buf.len(), n);
-        self.buf = &self.buf[len..];
-    }
-
-    #[inline]
-    fn step_in(&mut self) -> bool {
-        if let Some(limit) = self.limit.checked_sub(1) {
-            self.limit = limit;
-            true
-        } else {
-            false
-        }
-    }
-
-    #[inline]
-    fn step_out(&mut self) {
-        self.limit += 1;
-    }
-}
+use cbor4ii::core::utils::SliceReader;
 
 fuzz_target!(|data: &[u8]| {
     let mut reader = SliceReader::new(data);

--- a/hongg-fuzz/src/main.rs
+++ b/hongg-fuzz/src/main.rs
@@ -1,52 +1,17 @@
 use std::convert::Infallible;
 use honggfuzz::fuzz;
 use cbor4ii::core::Value;
-use cbor4ii::core::dec::{ self, Decode };
+use cbor4ii::core::dec::Decode;
+use cbor4ii::core::utils::SliceReader;
 use cbor4ii::DecodeError;
 use cbor4ii::serde::Deserializer;
 
-
-struct SliceReader<'a> {
-    buf: &'a [u8],
-    limit: usize
-}
-
-impl<'de> dec::Read<'de> for SliceReader<'de> {
-    type Error = Infallible;
-
-    #[inline]
-    fn fill<'b>(&'b mut self, want: usize) -> Result<dec::Reference<'de, 'b>, Self::Error> {
-        let len = core::cmp::min(self.buf.len(), want);
-        Ok(dec::Reference::Long(&self.buf[..len]))
-    }
-
-    #[inline]
-    fn advance(&mut self, n: usize) {
-        let len = core::cmp::min(self.buf.len(), n);
-        self.buf = &self.buf[len..];
-    }
-
-    #[inline]
-    fn step_in(&mut self) -> bool {
-        if let Some(limit) = self.limit.checked_sub(1) {
-            self.limit = limit;
-            true
-        } else {
-            false
-        }
-    }
-
-    #[inline]
-    fn step_out(&mut self) {
-        self.limit += 1;
-    }
-}
 
 pub fn from_slice<'a, T>(buf: &'a [u8]) -> Result<T, DecodeError<Infallible>>
     where
         T: serde::Deserialize<'a>,
     {
-        let reader = SliceReader { buf, limit: 256 };
+        let reader = SliceReader::new(buf);
         let mut deserializer = Deserializer::new(reader);
         serde::Deserialize::deserialize(&mut deserializer)
     }
@@ -56,7 +21,7 @@ fn main() {
         fuzz!(|data: &[u8]| {
             // decode
             {
-                let mut reader = SliceReader { buf: data, limit: 256 };
+                let mut reader = SliceReader::new(data);
                 let _ = Value::decode(&mut reader);
             }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -33,14 +33,18 @@ pub(crate) mod marker {
 }
 
 
-#[cfg(feature = "use_alloc")]
-pub mod buf_writer {
-    use crate::alloc::{ collections::TryReserveError, vec::Vec};
+pub mod utils {
+    #[cfg(feature = "use_alloc")]
+    use crate::alloc::vec::Vec;
+    #[cfg(feature = "use_alloc")]
     use crate::core::enc;
+    use crate::core::dec;
 
     /// An in-memory writer.
+    #[cfg(feature = "use_alloc")]
     pub struct BufWriter(Vec<u8>);
 
+    #[cfg(feature = "use_alloc")]
     impl BufWriter {
         /// Creates a new writer.
         pub fn new(buf: Vec<u8>) -> Self {
@@ -63,8 +67,9 @@ pub mod buf_writer {
         }
     }
 
+    #[cfg(feature = "use_alloc")]
     impl enc::Write for BufWriter {
-        type Error = TryReserveError;
+        type Error = crate::alloc::collections::TryReserveError;
 
         #[inline]
         fn push(&mut self, input: &[u8]) -> Result<(), Self::Error> {
@@ -74,9 +79,49 @@ pub mod buf_writer {
         }
     }
 
-}
+    /// An in-memory reader.
+    pub struct SliceReader<'a> {
+        buf: &'a [u8],
+        limit: usize
+    }
 
-#[cfg(feature = "use_alloc")] pub use buf_writer::BufWriter;
+    impl SliceReader<'_> {
+        pub fn new(buf: &[u8]) -> SliceReader<'_> {
+            SliceReader { buf, limit: 256 }
+        }
+    }
+
+    impl<'de> dec::Read<'de> for SliceReader<'de> {
+        type Error = core::convert::Infallible;
+
+        #[inline]
+        fn fill<'b>(&'b mut self, want: usize) -> Result<dec::Reference<'de, 'b>, Self::Error> {
+            let len = core::cmp::min(self.buf.len(), want);
+            Ok(dec::Reference::Long(&self.buf[..len]))
+        }
+
+        #[inline]
+        fn advance(&mut self, n: usize) {
+            let len = core::cmp::min(self.buf.len(), n);
+            self.buf = &self.buf[len..];
+        }
+
+        #[inline]
+        fn step_in(&mut self) -> bool {
+            if let Some(limit) = self.limit.checked_sub(1) {
+                self.limit = limit;
+                true
+            } else {
+                false
+            }
+        }
+
+        #[inline]
+        fn step_out(&mut self) {
+            self.limit += 1;
+        }
+    }
+}
 
 #[cfg(feature = "use_alloc")]
 #[derive(Debug, PartialEq)]

--- a/src/core.rs
+++ b/src/core.rs
@@ -32,6 +32,52 @@ pub(crate) mod marker {
     pub const BREAK: u8   = 0xff;
 }
 
+
+#[cfg(feature = "use_alloc")]
+pub mod buf_writer {
+    use crate::alloc::{ collections::TryReserveError, vec::Vec};
+    use crate::core::enc;
+
+    /// An in-memory writer.
+    pub struct BufWriter(Vec<u8>);
+
+    impl BufWriter {
+        /// Creates a new writer.
+        pub fn new(buf: Vec<u8>) -> Self {
+           BufWriter(buf)
+        }
+
+        /// Returns a reference to the underlying data.
+        pub fn buffer(&self) -> &[u8] {
+            &self.0
+        }
+
+        /// Returns the underlying vector.
+        pub fn into_inner(self) -> Vec<u8> {
+            self.0
+        }
+
+        /// Discards the underlying data.
+        pub fn clear(&mut self) {
+            self.0.clear();
+        }
+    }
+
+    impl enc::Write for BufWriter {
+        type Error = TryReserveError;
+
+        #[inline]
+        fn push(&mut self, input: &[u8]) -> Result<(), Self::Error> {
+            self.0.try_reserve(input.len())?;
+            self.0.extend_from_slice(input);
+            Ok(())
+        }
+    }
+
+}
+
+#[cfg(feature = "use_alloc")] pub use buf_writer::BufWriter;
+
 #[cfg(feature = "use_alloc")]
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -39,31 +39,18 @@ mod buf_writer {
     use crate::alloc::vec::Vec;
     use crate::alloc::collections::TryReserveError;
     use serde::Serialize;
-    use crate::core::enc;
+    use crate::core::{enc, BufWriter};
     use crate::serde::ser;
-
-    struct BufWriter(Vec<u8>);
-
-    impl enc::Write for BufWriter {
-        type Error = TryReserveError;
-
-        #[inline]
-        fn push(&mut self, input: &[u8]) -> Result<(), Self::Error> {
-            self.0.try_reserve(input.len())?;
-            self.0.extend_from_slice(input);
-            Ok(())
-        }
-    }
 
     /// Serializes a value to a writer.
     pub fn to_vec<T>(buf: Vec<u8>, value: &T)
         -> Result<Vec<u8>, enc::Error<TryReserveError>>
     where T: Serialize
     {
-        let writer = BufWriter(buf);
+        let writer = BufWriter::new(buf);
         let mut writer = ser::Serializer::new(writer);
         value.serialize(&mut writer)?;
-        Ok(writer.into_inner().0)
+        Ok(writer.into_inner().into_inner())
     }
 }
 


### PR DESCRIPTION
`BufWriter` can be used to serialize things into memory. The API is inspired
by `std::io::BufWriter`.

In case you wonder why the decode tests suddenly need `use_std`, that's been the case even before this change.