### PR TITLE
serde: give access to underlying writer

### DIFF
--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -16,6 +16,10 @@ impl<W> Serializer<W> {
     pub fn into_inner(self) -> W {
         self.writer
     }
+
+    pub fn writer(&mut self) -> &mut W {
+        &mut self.writer
+    }
 }
 
 impl<'a, W: enc::Write> serde::Serializer for &'a mut Serializer<W> {


### PR DESCRIPTION
When using the `Serializer` from an external crate it can be useful
to be able to access the underlying writer.

It turns out that the code I posted at https://github.com/quininer/cbor4ii/issues/13#issuecomment-1095342912 only works with this patch.