### PR TITLE
core: move IoReader and IoWriter into utils mod

### DIFF
--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -85,3 +85,72 @@ impl<'de> dec::Read<'de> for SliceReader<'de> {
         self.limit += 1;
     }
 }
+
+/// A writer to work with [`std::io::Write`].
+#[cfg(feature = "use_std")]
+pub struct IoWriter<W>(W);
+
+#[cfg(feature = "use_std")]
+impl<W> IoWriter<W> {
+    pub fn new(writer: W) -> Self {
+        IoWriter(writer)
+    }
+}
+
+#[cfg(feature = "use_std")]
+impl<W: std::io::Write> enc::Write for IoWriter<W> {
+    type Error = std::io::Error;
+
+    #[inline]
+    fn push(&mut self, input: &[u8]) -> Result<(), Self::Error> {
+        self.0.write_all(input)
+    }
+}
+
+
+/// A reader to work with [`std::io::BufRead`].
+///
+/// It has a recursion limit.
+#[cfg(feature = "use_std")]
+pub struct IoReader<R> {
+    reader: R,
+    limit: usize,
+}
+
+#[cfg(feature = "use_std")]
+impl<R> IoReader<R> {
+    pub fn new(reader: R) -> Self {
+        Self { reader, limit: 256 }
+    }
+}
+
+#[cfg(feature = "use_std")]
+impl<'de, R: std::io::BufRead> dec::Read<'de> for IoReader<R> {
+    type Error = std::io::Error;
+
+    #[inline]
+    fn fill<'b>(&'b mut self, _want: usize) -> Result<dec::Reference<'de, 'b>, Self::Error> {
+        let buf = self.reader.fill_buf()?;
+        Ok(dec::Reference::Short(buf))
+    }
+
+    #[inline]
+    fn advance(&mut self, n: usize) {
+        self.reader.consume(n);
+    }
+
+    #[inline]
+    fn step_in(&mut self) -> bool {
+        if let Some(limit) = self.limit.checked_sub(1) {
+            self.limit = limit;
+            true
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn step_out(&mut self) {
+        self.limit += 1;
+    }
+}

--- a/src/core/utils.rs
+++ b/src/core/utils.rs
@@ -95,6 +95,10 @@ impl<W> IoWriter<W> {
     pub fn new(writer: W) -> Self {
         IoWriter(writer)
     }
+
+    pub fn into_inner(self) -> W {
+        self.0
+    }
 }
 
 #[cfg(feature = "use_std")]
@@ -121,6 +125,10 @@ pub struct IoReader<R> {
 impl<R> IoReader<R> {
     pub fn new(reader: R) -> Self {
         Self { reader, limit: 256 }
+    }
+
+    pub fn into_inner(self) -> R {
+        self.reader
     }
 }
 


### PR DESCRIPTION
Refactor the `IoReader`/`IoWriter` into `core::utils`, so that it can be re-used
by external crates.

`IoWrite` was renamed to `IoWriter` for consistency.