### PR TITLE
core: decode_len can be private

### DIFF
--- a/src/core/dec.rs
+++ b/src/core/dec.rs
@@ -584,7 +584,7 @@ impl<'a> Decode<'a> for types::BadStr<crate::alloc::borrow::Cow<'a, [u8]>> {
 }
 
 #[inline]
-pub(crate) fn decode_len<'a, R: Read<'a>>(major: u8, byte: u8, reader: &mut R)
+fn decode_len<'a, R: Read<'a>>(major: u8, byte: u8, reader: &mut R)
     -> Result<Option<usize>, Error<R::Error>>
 {
     if byte != (marker::START | (major << 5)) {

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -314,25 +314,29 @@ impl<'de, 'a, R: dec::Read<'de>> Accessor<'a, R> {
     pub fn array(de: &'a mut Deserializer<R>)
         -> Result<Accessor<'a, R>, dec::Error<R::Error>>
     {
-        let byte = dec::pull_one(&mut de.reader)?;
-        let len = dec::decode_len(major::ARRAY, byte, &mut de.reader)?;
-        Ok(Accessor { de, len })
+        let array_start = dec::ArrayStart::decode(&mut de.reader)?;
+        Ok(Accessor {
+            de,
+            len: array_start.0,
+        })
     }
 
     #[inline]
     pub fn tuple(de: &'a mut Deserializer<R>, len: usize)
         -> Result<Accessor<'a, R>, dec::Error<R::Error>>
     {
-        let byte = dec::pull_one(&mut de.reader)?;
-        let arrlen = dec::decode_len(major::ARRAY, byte, &mut de.reader)?;
+        let array_start = dec::ArrayStart::decode(&mut de.reader)?;
 
-        if arrlen == Some(len) {
-            Ok(Accessor { de, len: arrlen })
+        if array_start.0 == Some(len) {
+            Ok(Accessor {
+                de,
+                len: array_start.0,
+            })
         } else {
             Err(dec::Error::RequireLength {
                 name: "tuple",
                 expect: len,
-                value: arrlen.unwrap_or(0)
+                value: array_start.0.unwrap_or(0),
             })
         }
     }
@@ -341,9 +345,11 @@ impl<'de, 'a, R: dec::Read<'de>> Accessor<'a, R> {
     pub fn map(de: &'a mut Deserializer<R>)
         -> Result<Accessor<'a, R>, dec::Error<R::Error>>
     {
-        let byte = dec::pull_one(&mut de.reader)?;
-        let len = dec::decode_len(major::MAP, byte, &mut de.reader)?;
-        Ok(Accessor { de, len })
+        let map_start = dec::MapStart::decode(&mut de.reader)?;
+        Ok(Accessor {
+            de,
+            len: map_start.0,
+        })
     }
 }
 


### PR DESCRIPTION
`core::dec::decode_len` doesn't need to be public to the crate, it
can be private. This PR is based on the comment by @quininer at
https://github.com/quininer/cbor4ii/issues/16#issuecomment-1098666029