### PR TITLE
core: tag parsing without value

### DIFF
--- a/src/core/dec.rs
+++ b/src/core/dec.rs
@@ -696,6 +696,15 @@ impl<'a, K: Decode<'a>, V: Decode<'a>> Decode<'a> for types::Map<Vec<(K, V)>> {
     }
 }
 
+pub struct TagStart(pub u64);
+
+impl<'a> Decode<'a> for TagStart {
+    #[inline]
+    fn decode_with<R: Read<'a>>(byte: u8, reader: &mut R) -> Result<Self, Error<R::Error>> {
+        TypeNum::new(!(major::TAG << 5), byte).decode_u64(reader).map(TagStart)
+    }
+}
+
 impl<'a, T: Decode<'a>> Decode<'a> for types::Tag<T> {
     #[inline]
     fn decode_with<R: Read<'a>>(byte: u8, reader: &mut R) -> Result<Self, Error<R::Error>> {

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -248,3 +248,23 @@ fn test_max_neg_8_as_i16() {
     let decoded = i16::decode(&mut reader).unwrap();
     assert_eq!(decoded, -256);
 }
+
+#[test]
+fn test_tag_start() {
+    let mut reader_tag_len1 = SliceReader::new(&[0xd8, 0x2a]);
+    let tag_len1 = dec::TagStart::decode(&mut reader_tag_len1).unwrap();
+    assert_eq!(tag_len1.0, 42);
+
+    let mut reader_tag_len2 = SliceReader::new(&[0xd9, 0x00, 0x2a]);
+    let tag_len2 = dec::TagStart::decode(&mut reader_tag_len2).unwrap();
+    assert_eq!(tag_len2.0, 42);
+
+    let mut reader_tag_len4 = SliceReader::new(&[0xda, 0x00, 0x00, 0x00, 0x2a]);
+    let tag_len4 = dec::TagStart::decode(&mut reader_tag_len4).unwrap();
+    assert_eq!(tag_len4.0, 42);
+
+    let mut reader_tag_len8 = SliceReader::new(
+        &[0xdb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a]);
+    let tag_len8 = dec::TagStart::decode(&mut reader_tag_len8).unwrap();
+    assert_eq!(tag_len8.0, 42);
+}


### PR DESCRIPTION
It's not easily possible to parse a tag without the value with the
current public API. This commit introduces a `TagStart`, which is
similar to `ArrayStart` and `MapStart`. It only parses the tag into
a `u64`, without advancing to the value.

This is the API I came up with, as always, if there's a better way
to solve my problem of parsing a tag value with the current public
API, I'm happy to hear about it.