### PR TITLE
Remove `*Start` types from dec module

### DIFF
--- a/src/core/dec.rs
+++ b/src/core/dec.rs
@@ -732,18 +732,12 @@ impl<'de> types::Tag<()> {
         TypeNum::new(&"tag", major::TAG).decode_u64(reader)
     }
 }
-impl<'de, T: Decode<'de>> types::Tag<T> {
-    #[inline]
-    pub fn value<R: Read<'de>>(reader: &mut R) -> Result<T, Error<R::Error>> {
-       T::decode(reader)
-    }
-}
 
 impl<'de, T: Decode<'de>> Decode<'de> for types::Tag<T> {
     #[inline]
     fn decode<R: Read<'de>>(reader: &mut R) -> Result<Self, Error<R::Error>> {
         let tag = types::Tag::tag(reader)?;
-        let value = types::Tag::value(reader)?;
+        let value = T::decode(reader)?;
         Ok(types::Tag(tag, value))
     }
 }

--- a/src/core/dec.rs
+++ b/src/core/dec.rs
@@ -576,7 +576,7 @@ impl<'de> Decode<'de> for &'de str {
 impl<'de> Decode<'de> for String {
     #[inline]
     fn decode<R: Read<'de>>(reader: &mut R) -> Result<Self, Error<R::Error>> {
-        let types::BadStr(buf) = <types::BadStr<Vec<u8>>>::decode(reader)?;
+        let types::UncheckedStr(buf) = <types::UncheckedStr<Vec<u8>>>::decode(reader)?;
         String::from_utf8(buf).map_err(|_| Error::require_utf8(&"str"))
     }
 }
@@ -588,7 +588,7 @@ impl<'de> Decode<'de> for crate::alloc::borrow::Cow<'de, str> {
         use crate::alloc::borrow::Cow;
 
         let name = &"str";
-        let types::BadStr(buf) = <types::BadStr<Cow<'_, [u8]>>>::decode(reader)?;
+        let types::UncheckedStr(buf) = <types::UncheckedStr<Cow<'_, [u8]>>>::decode(reader)?;
 
         match buf {
             Cow::Borrowed(buf) => core::str::from_utf8(buf)
@@ -601,29 +601,29 @@ impl<'de> Decode<'de> for crate::alloc::borrow::Cow<'de, str> {
     }
 }
 
-impl<'de> Decode<'de> for types::BadStr<&'de [u8]> {
+impl<'de> Decode<'de> for types::UncheckedStr<&'de [u8]> {
     #[inline]
     fn decode<R: Read<'de>>(reader: &mut R) -> Result<Self, Error<R::Error>> {
         let buf = decode_bytes_ref(&"str", major::STRING, reader)?;
-        Ok(types::BadStr(buf))
+        Ok(types::UncheckedStr(buf))
     }
 }
 
 #[cfg(feature = "use_alloc")]
-impl<'de> Decode<'de> for types::BadStr<Vec<u8>> {
+impl<'de> Decode<'de> for types::UncheckedStr<Vec<u8>> {
     #[inline]
     fn decode<R: Read<'de>>(reader: &mut R) -> Result<Self, Error<R::Error>> {
         let buf = decode_buf(&"str", major::STRING, reader)?;
-        Ok(types::BadStr(buf))
+        Ok(types::UncheckedStr(buf))
     }
 }
 
 #[cfg(feature = "use_alloc")]
-impl<'de> Decode<'de> for types::BadStr<crate::alloc::borrow::Cow<'de, [u8]>> {
+impl<'de> Decode<'de> for types::UncheckedStr<crate::alloc::borrow::Cow<'de, [u8]>> {
     #[inline]
     fn decode<R: Read<'de>>(reader: &mut R) -> Result<Self, Error<R::Error>> {
         let buf = decode_cow_buf(&"str", major::STRING, reader)?;
-        Ok(types::BadStr(buf))
+        Ok(types::UncheckedStr(buf))
     }
 }
 

--- a/src/core/enc.rs
+++ b/src/core/enc.rs
@@ -215,16 +215,16 @@ impl Encode for types::Bytes<&'_ [u8]> {
 impl Encode for &'_ str {
     #[inline]
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        types::BadStr::bounded(self.len(), writer)?;
+        types::UncheckedStr::bounded(self.len(), writer)?;
         writer.push(self.as_bytes())?;
         Ok(())
     }
 }
 
-impl Encode for types::BadStr<&'_ [u8]> {
+impl Encode for types::UncheckedStr<&'_ [u8]> {
     #[inline]
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        types::BadStr::bounded(self.0.len(), writer)?;
+        types::UncheckedStr::bounded(self.0.len(), writer)?;
         writer.push(self.0)?;
         Ok(())
     }
@@ -287,7 +287,7 @@ bound_unbound_end! {
     types::Array<()>, major::ARRAY;
     types::Map<()>, major::MAP;
     types::Bytes<()>, major::BYTES;
-    types::BadStr<()>, major::STRING;
+    types::UncheckedStr<()>, major::STRING;
 }
 
 impl<T: Encode> Encode for types::Tag<T> {
@@ -553,10 +553,10 @@ fn test_encoded() -> anyhow::Result<()> {
     // (_ "strea", "ming")
     {
         buf.0.clear();
-        types::BadStr::unbounded(&mut buf)?;
+        types::UncheckedStr::unbounded(&mut buf)?;
         "strea".encode(&mut buf)?;
         "ming".encode(&mut buf)?;
-        types::BadStr::end(&mut buf)?;
+        types::UncheckedStr::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0x7f657374726561646d696e67ff");
     }

--- a/src/core/enc.rs
+++ b/src/core/enc.rs
@@ -206,18 +206,8 @@ encode_ix!(
 impl Encode for types::Bytes<&'_ [u8]> {
     #[inline]
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        TypeNum::new(major::BYTES << 5, self.0.len() as u64).encode(writer)?;
+        types::Bytes::bounded(self.0.len(), writer)?;
         writer.push(self.0)?;
-        Ok(())
-    }
-}
-
-pub struct BytesStart;
-
-impl Encode for BytesStart {
-    #[inline]
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        writer.push(&[(major::BYTES << 5) | marker::START])?;
         Ok(())
     }
 }
@@ -225,7 +215,7 @@ impl Encode for BytesStart {
 impl Encode for &'_ str {
     #[inline]
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        TypeNum::new(major::STRING << 5, self.len() as u64).encode(writer)?;
+        types::BadStr::bounded(self.len(), writer)?;
         writer.push(self.as_bytes())?;
         Ok(())
     }
@@ -234,18 +224,8 @@ impl Encode for &'_ str {
 impl Encode for types::BadStr<&'_ [u8]> {
     #[inline]
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        TypeNum::new(major::STRING << 5, self.0.len() as u64).encode(writer)?;
+        types::BadStr::bounded(self.0.len(), writer)?;
         writer.push(self.0)?;
-        Ok(())
-    }
-}
-
-pub struct StrStart;
-
-impl Encode for StrStart {
-    #[inline]
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        writer.push(&[(major::STRING << 5) | marker::START])?;
         Ok(())
     }
 }
@@ -253,7 +233,7 @@ impl Encode for StrStart {
 impl<T: Encode> Encode for &'_ [T] {
     #[inline]
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        ArrayStartBounded(self.len()).encode(writer)?;
+        types::Array::bounded(self.len(), writer)?;
         for value in self.iter() {
             value.encode(writer)?;
         }
@@ -261,29 +241,10 @@ impl<T: Encode> Encode for &'_ [T] {
     }
 }
 
-pub struct ArrayStartBounded(pub usize);
-pub struct ArrayStartUnbounded;
-
-impl Encode for ArrayStartBounded {
-    #[inline]
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        TypeNum::new(major::ARRAY << 5, self.0 as u64).encode(writer)?;
-        Ok(())
-    }
-}
-
-impl Encode for ArrayStartUnbounded {
-    #[inline]
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        writer.push(&[(major::ARRAY << 5) | marker::START])?;
-        Ok(())
-    }
-}
-
 impl<K: Encode, V: Encode> Encode for types::Map<&'_ [(K, V)]> {
     #[inline]
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        MapStartBounded(self.0.len()).encode(writer)?;
+        types::Map::bounded(self.0.len(), writer)?;
         for (k, v) in self.0.iter() {
             k.encode(writer)?;
             v.encode(writer)?;
@@ -292,23 +253,41 @@ impl<K: Encode, V: Encode> Encode for types::Map<&'_ [(K, V)]> {
     }
 }
 
-pub struct MapStartBounded(pub usize);
-pub struct MapStartUnbounded;
+/// Implementation of markers for types with indefinite length suppport.
+macro_rules! bound_unbound_end {
+    ( $( $t:ty , $major:expr );* $( ; )? ) => {
+        $(
+            impl $t {
+                /// Encode the type with the length prefix.
+                #[inline]
+                pub fn bounded<W: Write>(len: usize, writer: &mut W) -> Result<(), Error<W::Error>> {
+                    TypeNum::new($major << 5, len as u64).encode(writer)?;
+                    Ok(())
+                }
 
-impl Encode for MapStartBounded {
-    #[inline]
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        TypeNum::new(major::MAP << 5, self.0 as u64).encode(writer)?;
-        Ok(())
+                /// Encode the type with an indefinite size marker.
+                #[inline]
+                pub fn unbounded<W: Write>(writer: &mut W) -> Result<(), Error<W::Error>> {
+                    writer.push(&[($major << 5) | marker::START])?;
+                    Ok(())
+                }
+
+                /// Encode the indefinite size end marker.
+                #[inline]
+                pub fn end<W: Write>(writer: &mut W) -> Result<(), Error<W::Error>> {
+                    writer.push(&[marker::BREAK])?;
+                    Ok(())
+                }
+            }
+        )*
     }
 }
 
-impl Encode for MapStartUnbounded {
-    #[inline]
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        writer.push(&[(major::MAP << 5) | marker::START])?;
-        Ok(())
-    }
+bound_unbound_end! {
+    types::Array<()>, major::ARRAY;
+    types::Map<()>, major::MAP;
+    types::Bytes<()>, major::BYTES;
+    types::BadStr<()>, major::STRING;
 }
 
 impl<T: Encode> Encode for types::Tag<T> {
@@ -386,16 +365,6 @@ impl Encode for f64 {
     fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
         let [x0, x1, x2, x3, x4, x5, x6, x7] = self.to_be_bytes();
         writer.push(&[marker::F64, x0, x1, x2, x3, x4, x5, x6, x7])?;
-        Ok(())
-    }
-}
-
-pub struct End;
-
-impl Encode for End {
-    #[inline]
-    fn encode<W: Write>(&self, writer: &mut W) -> Result<(), Error<W::Error>> {
-        writer.push(&[marker::BREAK])?;
         Ok(())
     }
 }
@@ -538,7 +507,7 @@ fn test_encoded() -> anyhow::Result<()> {
     // [1, [2, 3], [4, 5]]
     {
         buf.0.clear();
-        ArrayStartBounded(3).encode(&mut buf)?;
+        types::Array::bounded(3, &mut buf)?;
         1u8.encode(&mut buf)?;
         (&[2u64, 3u64][..]).encode(&mut buf)?;
         (&[4i32, 5i32][..]).encode(&mut buf)?;
@@ -549,7 +518,7 @@ fn test_encoded() -> anyhow::Result<()> {
     // {"a": 1, "b": [2, 3]}
     {
         buf.0.clear();
-        MapStartBounded(2).encode(&mut buf)?;
+        types::Map::bounded(2, &mut buf)?;
         "a".encode(&mut buf)?;
         1u32.encode(&mut buf)?;
         "b".encode(&mut buf)?;
@@ -561,9 +530,9 @@ fn test_encoded() -> anyhow::Result<()> {
     // ["a", {"b": "c"}]
     {
         buf.0.clear();
-        ArrayStartBounded(2).encode(&mut buf)?;
+        types::Array::bounded(2, &mut buf)?;
         "a".encode(&mut buf)?;
-        MapStartBounded(1).encode(&mut buf)?;
+        types::Map::bounded(1, &mut buf)?;
         "b".encode(&mut buf)?;
         "c".encode(&mut buf)?;
         let output = hex(&buf.0);
@@ -573,10 +542,10 @@ fn test_encoded() -> anyhow::Result<()> {
     // (_ h'0102', h'030405')
     {
         buf.0.clear();
-        BytesStart.encode(&mut buf)?;
+        types::Bytes::unbounded(&mut buf)?;
         types::Bytes(&[0x01, 0x02][..]).encode(&mut buf)?;
         types::Bytes(&[0x03, 0x04, 0x05][..]).encode(&mut buf)?;
-        End.encode(&mut buf)?;
+        types::Bytes::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0x5f42010243030405ff");
     }
@@ -584,10 +553,10 @@ fn test_encoded() -> anyhow::Result<()> {
     // (_ "strea", "ming")
     {
         buf.0.clear();
-        StrStart.encode(&mut buf)?;
+        types::BadStr::unbounded(&mut buf)?;
         "strea".encode(&mut buf)?;
         "ming".encode(&mut buf)?;
-        End.encode(&mut buf)?;
+        types::BadStr::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0x7f657374726561646d696e67ff");
     }
@@ -595,8 +564,8 @@ fn test_encoded() -> anyhow::Result<()> {
     // [_ ]
     {
         buf.0.clear();
-        ArrayStartUnbounded.encode(&mut buf)?;
-        End.encode(&mut buf)?;
+        types::Array::unbounded(&mut buf)?;
+        types::Array::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0x9fff");
     }
@@ -604,14 +573,14 @@ fn test_encoded() -> anyhow::Result<()> {
     // [_ 1, [2, 3], [_ 4, 5]]
     {
         buf.0.clear();
-        ArrayStartUnbounded.encode(&mut buf)?;
+        types::Array::unbounded(&mut buf)?;
         1u64.encode(&mut buf)?;
         (&[2u32, 3u32][..]).encode(&mut buf)?;
-        ArrayStartUnbounded.encode(&mut buf)?;
+        types::Array::unbounded(&mut buf)?;
         4u64.encode(&mut buf)?;
         5u64.encode(&mut buf)?;
-        End.encode(&mut buf)?;
-        End.encode(&mut buf)?;
+        types::Array::end(&mut buf)?;
+        types::Array::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0x9f018202039f0405ffff");
     }
@@ -619,11 +588,11 @@ fn test_encoded() -> anyhow::Result<()> {
     // [_ 1, [2, 3], [4, 5]]
     {
         buf.0.clear();
-        ArrayStartUnbounded.encode(&mut buf)?;
+        types::Array::unbounded(&mut buf)?;
         1u64.encode(&mut buf)?;
         (&[2u32, 3u32][..]).encode(&mut buf)?;
         (&[4u32, 5u32][..]).encode(&mut buf)?;
-        End.encode(&mut buf)?;
+        types::Array::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0x9f01820203820405ff");
     }
@@ -631,13 +600,13 @@ fn test_encoded() -> anyhow::Result<()> {
     // [1, [2, 3], [_ 4, 5]]
     {
         buf.0.clear();
-        ArrayStartBounded(3).encode(&mut buf)?;
+        types::Array::bounded(3, &mut buf)?;
         1u64.encode(&mut buf)?;
         (&[2u32, 3u32][..]).encode(&mut buf)?;
-        ArrayStartUnbounded.encode(&mut buf)?;
+        types::Array::unbounded(&mut buf)?;
         4u64.encode(&mut buf)?;
         5u64.encode(&mut buf)?;
-        End.encode(&mut buf)?;
+        types::Array::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0x83018202039f0405ff");
     }
@@ -645,12 +614,12 @@ fn test_encoded() -> anyhow::Result<()> {
     // [1, [_ 2, 3], [4, 5]]
     {
         buf.0.clear();
-        ArrayStartBounded(3).encode(&mut buf)?;
+        types::Array::bounded(3, &mut buf)?;
         1u64.encode(&mut buf)?;
-        ArrayStartUnbounded.encode(&mut buf)?;
+        types::Array::unbounded(&mut buf)?;
         2u64.encode(&mut buf)?;
         3u64.encode(&mut buf)?;
-        End.encode(&mut buf)?;
+        types::Array::end(&mut buf)?;
         (&[4u32, 5u32][..]).encode(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0x83019f0203ff820405");
@@ -659,11 +628,11 @@ fn test_encoded() -> anyhow::Result<()> {
     // [_ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
     {
         buf.0.clear();
-        ArrayStartUnbounded.encode(&mut buf)?;
+        types::Array::unbounded(&mut buf)?;
         for i in 1u32..=25 {
             i.encode(&mut buf)?;
         }
-        End.encode(&mut buf)?;
+        types::Array::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0x9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff");
     }
@@ -671,15 +640,15 @@ fn test_encoded() -> anyhow::Result<()> {
     // {_ "a": 1, "b": [_ 2, 3]}
     {
         buf.0.clear();
-        MapStartUnbounded.encode(&mut buf)?;
+        types::Map::unbounded(&mut buf)?;
         "a".encode(&mut buf)?;
         1u32.encode(&mut buf)?;
         "b".encode(&mut buf)?;
-        ArrayStartUnbounded.encode(&mut buf)?;
+        types::Array::unbounded(&mut buf)?;
         2i32.encode(&mut buf)?;
         3i32.encode(&mut buf)?;
-        End.encode(&mut buf)?;
-        End.encode(&mut buf)?;
+        types::Array::end(&mut buf)?;
+        types::Array::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0xbf61610161629f0203ffff");
     }
@@ -687,12 +656,12 @@ fn test_encoded() -> anyhow::Result<()> {
     // ["a", {_ "b": "c"}]
     {
         buf.0.clear();
-        ArrayStartBounded(2).encode(&mut buf)?;
+        types::Array::bounded(2, &mut buf)?;
         "a".encode(&mut buf)?;
-        MapStartUnbounded.encode(&mut buf)?;
+        types::Map::unbounded(&mut buf)?;
         "b".encode(&mut buf)?;
         "c".encode(&mut buf)?;
-        End.encode(&mut buf)?;
+        types::Array::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0x826161bf61626163ff");
     }
@@ -700,12 +669,12 @@ fn test_encoded() -> anyhow::Result<()> {
     // {_ "Fun": true, "Amt": -2}
     {
         buf.0.clear();
-        MapStartUnbounded.encode(&mut buf)?;
+        types::Map::unbounded(&mut buf)?;
         "Fun".encode(&mut buf)?;
         true.encode(&mut buf)?;
         "Amt".encode(&mut buf)?;
         (-2i32).encode(&mut buf)?;
-        End.encode(&mut buf)?;
+        types::Map::end(&mut buf)?;
         let output = hex(&buf.0);
         assert_eq!(output, "0xbf6346756ef563416d7421ff");
     }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -4,7 +4,7 @@ pub struct Negative<T>(pub T);
 
 pub struct Bytes<T>(pub T);
 
-pub struct BadStr<T>(pub T);
+pub struct UncheckedStr<T>(pub T);
 
 pub struct Array<T>(pub T);
 

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -6,6 +6,8 @@ pub struct Bytes<T>(pub T);
 
 pub struct BadStr<T>(pub T);
 
+pub struct Array<T>(pub T);
+
 pub struct Map<T>(pub T);
 
 pub struct Tag<T>(pub u64, pub T);

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -322,10 +322,10 @@ impl<'de, 'a, R: dec::Read<'de>> Accessor<'a, R> {
     pub fn array(_name: error::StaticStr, de: &'a mut Deserializer<R>)
         -> Result<Accessor<'a, R>, dec::Error<R::Error>>
     {
-        let array_start = dec::ArrayStart::decode(&mut de.reader)?;
+        let len = types::Array::len(&mut de.reader)?;
         Ok(Accessor {
             de,
-            len: array_start.0,
+            len,
         })
     }
 
@@ -333,15 +333,15 @@ impl<'de, 'a, R: dec::Read<'de>> Accessor<'a, R> {
     pub fn tuple(name: error::StaticStr, de: &'a mut Deserializer<R>, len: usize)
         -> Result<Accessor<'a, R>, dec::Error<R::Error>>
     {
-        let array_start = dec::ArrayStart::decode(&mut de.reader)?;
+        let array_len = types::Array::len(&mut de.reader)?;
 
-        if array_start.0 == Some(len) {
+        if array_len == Some(len) {
             Ok(Accessor {
                 de,
-                len: array_start.0,
+                len: array_len,
             })
         } else {
-            Err(dec::Error::require_length(name, array_start.0))
+            Err(dec::Error::require_length(name, array_len))
         }
     }
 
@@ -349,10 +349,10 @@ impl<'de, 'a, R: dec::Read<'de>> Accessor<'a, R> {
     pub fn map(_name: error::StaticStr, de: &'a mut Deserializer<R>)
         -> Result<Accessor<'a, R>, dec::Error<R::Error>>
     {
-        let map_start = dec::MapStart::decode(&mut de.reader)?;
+        let len = types::Map::len(&mut de.reader)?;
         Ok(Accessor {
             de,
-            len: map_start.0,
+            len,
         })
     }
 }

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -473,8 +473,8 @@ impl<W: enc::Write> fmt::Write for FmtWriter<'_, W> {
                     self.pos += input.len();
                 } else {
                     self.state = State::Segment;
-                    try_!(types::BadStr::unbounded(self.inner));
-                    try_!(types::BadStr(&self.buf[..self.pos]).encode(self.inner));
+                    try_!(types::UncheckedStr::unbounded(self.inner));
+                    try_!(types::UncheckedStr(&self.buf[..self.pos]).encode(self.inner));
                     try_!(input.encode(self.inner));
                 }
 
@@ -507,8 +507,8 @@ impl<W: enc::Write> FmtWriter<'_, W> {
     #[inline]
     fn flush(self) -> Result<(), enc::Error<W::Error>> {
         match self.state {
-            State::Short => types::BadStr(&self.buf[..self.pos]).encode(self.inner),
-            State::Segment => types::BadStr::end(self.inner),
+            State::Short => types::UncheckedStr(&self.buf[..self.pos]).encode(self.inner),
+            State::Segment => types::UncheckedStr::end(self.inner),
             State::Error(err) => Err(err)
         }
     }

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -34,11 +34,11 @@ fn test_decode_value() {
 #[test]
 fn test_decode_buf_segment() -> anyhow::Result<()> {
     let mut writer = BufWriter::new(Vec::new());
-    types::BadStr::unbounded(&mut writer)?;
+    types::UncheckedStr::unbounded(&mut writer)?;
     "test".encode(&mut writer)?;
     "test2".encode(&mut writer)?;
     "test3".encode(&mut writer)?;
-    types::BadStr::end(&mut writer)?;
+    types::UncheckedStr::end(&mut writer)?;
 
     let mut reader = SliceReader::new(writer.buffer());
     let output = String::decode(&mut reader)?;

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -34,11 +34,11 @@ fn test_decode_value() {
 #[test]
 fn test_decode_buf_segment() -> anyhow::Result<()> {
     let mut writer = BufWriter::new(Vec::new());
-    enc::StrStart.encode(&mut writer)?;
+    types::BadStr::unbounded(&mut writer)?;
     "test".encode(&mut writer)?;
     "test2".encode(&mut writer)?;
     "test3".encode(&mut writer)?;
-    enc::End.encode(&mut writer)?;
+    types::BadStr::end(&mut writer)?;
 
     let mut reader = SliceReader::new(writer.buffer());
     let output = String::decode(&mut reader)?;
@@ -94,11 +94,11 @@ fn test_decode_array_map() -> anyhow::Result<()> {
 
     // map unbounded
     let mut writer = BufWriter::new(Vec::new());
-    enc::MapStartUnbounded.encode(&mut writer)?;
+    types::Map::unbounded(&mut writer)?;
     for i in 0u64..6 {
         i.encode(&mut writer)?;
     }
-    enc::End.encode(&mut writer)?;
+    types::Map::end(&mut writer)?;
 
     let mut reader = SliceReader::new(writer.buffer());
     let len = types::Map::len(&mut reader)?;

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -271,15 +271,6 @@ fn test_tag() {
 }
 
 #[test]
-fn test_tag_value() {
-    let mut reader = SliceReader::new(&[0xc1, 0x1a, 0x51, 0x4b, 0x67, 0xb0]);
-    let tag = types::Tag::tag(&mut reader).unwrap();
-    assert_eq!(tag, 1);
-    let value: u64 = types::Tag::value(&mut reader).unwrap();
-    assert_eq!(value,  1363896240u64);
-}
-
-#[test]
 fn test_ignored_any_eof_loop() {
     let mut buf = BufWriter::new(Vec::new());
     "aaa".encode(&mut buf).unwrap();


### PR DESCRIPTION
Instead of having `TagStart`, `ArrayStart` and `MapStart`, implement
functions directly on the concrete types.

This PR tries to address the comment at https://github.com/quininer/cbor4ii/pull/22#issuecomment-1108791827.

I've based it on the `0.3` branch. But this also means that I haven't tested it with my own Serde implementation (which is still on on 0.2.x), but I don't see a reason why it shouldn't work there. I didn't want to spent too much time on this PR as I'm not sure if that's a good approach or not. Though I'm happy to spend more time on it, in case it's the right direction.