### PR TITLE
Remove extra "reader.advance" from deserialize_any F16 parsing.

### DIFF
--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -90,7 +90,6 @@ impl<'de, 'a, R: dec::Read<'de>> serde::Deserializer<'de> for &'a mut Deserializ
                 },
                 #[cfg(feature = "half-f16")]
                 marker::F16 => {
-                    de.reader.advance(1);
                     let v = half::f16::decode(&mut de.reader)?;
                     visitor.visit_f32(v.into())
                 },


### PR DESCRIPTION
This fixes issue #29 by removing an extra reader.advance call in deserialize_any that was causing F16 parsing to fail.