### PR TITLE
Enabled `serde/alloc` on `serde1` features was set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 use_std = [ "use_alloc" ]
 use_alloc = []
 half-f16 = [ "half" ]
-serde1 = [ "serde", "use_alloc" ]
+serde1 = [ "serde/alloc", "use_alloc" ]
 
 [dependencies]
 half = { version = "2", default-features = false, optional = true }


### PR DESCRIPTION
Current project won't build with resolver 2 enabled:

```toml
[workspace]
resolver = "2"
```